### PR TITLE
A way to set the seed of RandomNumber.cs

### DIFF
--- a/src/Faker/RandomNumber.cs
+++ b/src/Faker/RandomNumber.cs
@@ -8,12 +8,12 @@ namespace Faker
     public static class RandomNumber
     {
         private static Random _rnd = new Random();
-
-		public static void ResetSeed(int seed)
-		{
-			_rnd = new Random(seed);
-		}
-
+        
+        public static void ResetSeed(int seed)
+        {
+            _rnd = new Random(seed);
+        }
+        
         public static int Next()
         {
             return _rnd.Next();


### PR DESCRIPTION
An use-case I have is making data mocks that are random, but are repeated on every run. 

With this simple patch you can set the seed using `RandomNumber.ResetSeed(1337);` before each mock.
